### PR TITLE
update podspec, point to specific version of kingfisher

### DIFF
--- a/PhotoSlider.podspec
+++ b/PhotoSlider.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PhotoSlider"
-  s.version          = "0.13.1"
+  s.version          = "0.13.2"
   s.summary          = "PhotoSlider can a simple photo slider and delete slider with swiping."
   s.homepage         = "https://github.com/nakajijapan/PhotoSlider"
   s.license          = 'MIT'
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
     'PhotoSlider' => ['Sources/Assets/*.png']
   }
 
-  s.dependency 'Kingfisher'
+  s.dependency 'Kingfisher', '~> 2.0.1'
 end


### PR DESCRIPTION
@nakajijapan 
##### Problem

I was getting errors with the tagged version not specifying a dependancy version for kingfisher, but also not having this commit https://github.com/nakajijapan/PhotoSlider/commit/779d9d4b908ca87b5534b59f59e653c417d36fdd.
##### Solution

Use the updated version of kingfisher explicitly, and update the pod spec
