### PR TITLE
Fix orientation bug when device is laying on surface

### DIFF
--- a/PhotoSliderDemo/ViewController.swift
+++ b/PhotoSliderDemo/ViewController.swift
@@ -127,7 +127,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
         
-        if UIDeviceOrientationIsPortrait(UIDevice.currentDevice().orientation) {
+        if self.view.bounds.size.width < self.view.bounds.height {
 
             return CGSize(width:self.tableView.bounds.size.width, height:self.tableView.bounds.size.width)
 
@@ -210,7 +210,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         let statusBarHeight = UIApplication.sharedApplication().statusBarFrame.height
         var frame = CGRectZero
         
-        if UIDeviceOrientationIsPortrait(UIDevice.currentDevice().orientation) {
+        if self.view.bounds.size.width < self.view.bounds.height {
 
             if image.size.height < image.size.width {
                 let width = (sourceImageView.image!.size.width * sourceImageView.bounds.size.width) / sourceImageView.image!.size.height

--- a/PhotoSliderDemo/ViewController.swift
+++ b/PhotoSliderDemo/ViewController.swift
@@ -97,7 +97,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         
         if indexPath.row == 0 {
             
-            if self.interfaceOrientation.isPortrait {
+            if self.view.bounds.size.width < self.view.bounds.height {
                 return tableView.bounds.size.width
             } else {
                 return tableView.bounds.size.height

--- a/PhotoSliderDemo/ViewController.swift
+++ b/PhotoSliderDemo/ViewController.swift
@@ -96,7 +96,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
         
         if indexPath.row == 0 {
-            if UIDeviceOrientationIsPortrait(UIDevice.currentDevice().orientation) {
+            
+            if self.interfaceOrientation.isPortrait {
                 return tableView.bounds.size.width
             } else {
                 return tableView.bounds.size.height

--- a/Sources/Classes/ViewController.swift
+++ b/Sources/Classes/ViewController.swift
@@ -502,7 +502,7 @@ public class ViewController:UIViewController, UIScrollViewDelegate, PhotoSliderI
         var height = CGFloat(0.0)
         var width = CGFloat(0.0)
         
-        if self.interfaceOrientation.isPortrait {
+        if self.view.bounds.width < self.view.bounds.height {
                 
             height = (CGRectGetWidth(self.view.frame) * sourceImage.size.height) / sourceImage.size.width
             width  = CGRectGetWidth(self.view.frame)

--- a/Sources/Classes/ViewController.swift
+++ b/Sources/Classes/ViewController.swift
@@ -502,7 +502,7 @@ public class ViewController:UIViewController, UIScrollViewDelegate, PhotoSliderI
         var height = CGFloat(0.0)
         var width = CGFloat(0.0)
         
-        if UIDeviceOrientationIsPortrait(UIDevice.currentDevice().orientation) {
+        if self.interfaceOrientation.isPortrait {
                 
             height = (CGRectGetWidth(self.view.frame) * sourceImage.size.height) / sourceImage.size.width
             width  = CGRectGetWidth(self.view.frame)


### PR DESCRIPTION
UIDeviceOrientation can be not only .Portrait and .Landscape, but also .Flat.
So I'm using the interface orientation of the view controller itself to determine the right rect. 
(tested only for portrait because my project is portrait only)
