### PR TITLE
Support Multiple ImageLoader

### DIFF
--- a/PhotoSlider.xcodeproj/project.pbxproj
+++ b/PhotoSlider.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		94530E041E247C6100D12C16 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94530E031E247C6100D12C16 /* ImageLoader.swift */; };
+		94530E141E247CA300D12C16 /* KingfisherImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94530E131E247CA300D12C16 /* KingfisherImageLoader.swift */; };
 		DC0E42021C3182080090AC94 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E41C71C317E850090AC94 /* ImageView.swift */; };
 		DC0E42031C3182090090AC94 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E41C81C317E850090AC94 /* Photo.swift */; };
 		DC0E42041C31820C0090AC94 /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E41C91C317E850090AC94 /* ProgressView.swift */; };
@@ -108,6 +110,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		94530E031E247C6100D12C16 /* ImageLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
+		94530E131E247CA300D12C16 /* KingfisherImageLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KingfisherImageLoader.swift; sourceTree = "<group>"; };
 		DC0E41BD1C317E850090AC94 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = PhotoSlider/Info.plist; sourceTree = "<group>"; };
 		DC0E41BE1C317E850090AC94 /* PhotoSlider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PhotoSlider.h; path = PhotoSlider/PhotoSlider.h; sourceTree = "<group>"; };
 		DC0E41C21C317E850090AC94 /* PhotoSliderClose.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = PhotoSliderClose.png; sourceTree = "<group>"; };
@@ -192,6 +196,8 @@
 				DC0E41CA1C317E850090AC94 /* ViewController.swift */,
 				DC0E41CB1C317E850090AC94 /* ZoomingAnimationController.swift */,
 				DC3EE1DA1D9C96610046AFE2 /* UIImage+PhotoSlider.swift */,
+				94530E031E247C6100D12C16 /* ImageLoader.swift */,
+				94530E131E247CA300D12C16 /* KingfisherImageLoader.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -399,7 +405,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				94530E041E247C6100D12C16 /* ImageLoader.swift in Sources */,
 				DC0E42031C3182090090AC94 /* Photo.swift in Sources */,
+				94530E141E247CA300D12C16 /* KingfisherImageLoader.swift in Sources */,
 				DC0E42021C3182080090AC94 /* ImageView.swift in Sources */,
 				DC0E42041C31820C0090AC94 /* ProgressView.swift in Sources */,
 				DC3EE1DB1D9C96610046AFE2 /* UIImage+PhotoSlider.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -162,6 +162,51 @@ You can handle the following event:
 - optional func photoSliderControllerWillDismiss(viewController: PhotoSlider.ViewController)
 - optional func photoSliderControllerDidDismiss(viewController: PhotoSlider.ViewController)
 
+## Multiple Image Loader
+
+PhotoSlider use Kingfisher for remote image.
+If use SDWebImage in your project, image cache is not shared between Kingfisher and SDWebImage.
+In this case you can make custom ImageLoader. default ImageLoader is Kignfisher.
+
+Here is how to change SDWebImage.
+
+First, create custom ImageLoader.
+
+```swift
+import PhotoSlider
+
+class PhotoSliderSDImageLoader: PhotoSlider.ImageLoader {
+    public func load(
+        imageView: UIImageView?,
+        fromURL url: URL?,
+        progress: @escaping PhotoSlider.ImageLoader.ProgressBlock,
+        completion: @escaping PhotoSlider.ImageLoader.CompletionBlock)
+    {
+        imageView?.sd_setImage(
+            withURL: url,
+            placeholderImage: nil,
+            options: SDWebImageOptions.retryFailed,
+            progress: { (receivedSize, totalSize) in
+                progress(receivedSize, totalSize)
+            },
+            completed: { (image, _, _, _) in
+                completion(image)
+            }
+        )
+    }
+}
+```
+
+and set ImageLoader.
+
+```swift
+let slider = PhotoSlider.ViewController(imageURLs: images)
+slider.modalPresentationStyle = .OverCurrentContext
+slider.modalTransitionStyle = UIModalTransitionStyle.CrossDissolve
+slider.index = indexPath.row
+slider.imageLoader = PhotoSliderSDImageLoader()
+present(slider, animated: true, completion: nil)
+```
 
 ## Author
 

--- a/Sources/Classes/ImageLoader.swift
+++ b/Sources/Classes/ImageLoader.swift
@@ -1,0 +1,21 @@
+//
+//  ImageLoader.swift
+//  PhotoSlider
+//
+//  Created by ChangHoon Jung on 2017. 1. 10..
+//  Copyright © 2017년 nakajijapan. All rights reserved.
+//
+
+import Foundation
+
+public protocol ImageLoader: class {
+    typealias ProgressBlock = (_ receivedSize: Int, _ totalSize: Int) -> Void
+    typealias CompletionBlock = (_ image: UIImage?) -> Void
+    
+    func load(
+        imageView: UIImageView?,
+        fromURL url: URL?,
+        progress: @escaping ImageLoader.ProgressBlock,
+        completion: @escaping ImageLoader.CompletionBlock)
+}
+

--- a/Sources/Classes/ImageLoader.swift
+++ b/Sources/Classes/ImageLoader.swift
@@ -11,11 +11,10 @@ import Foundation
 public protocol ImageLoader: class {
     typealias ProgressBlock = (_ receivedSize: Int, _ totalSize: Int) -> Void
     typealias CompletionBlock = (_ image: UIImage?) -> Void
-    
+
     func load(
         imageView: UIImageView?,
         fromURL url: URL?,
         progress: @escaping ImageLoader.ProgressBlock,
         completion: @escaping ImageLoader.CompletionBlock)
 }
-

--- a/Sources/Classes/ImageView.swift
+++ b/Sources/Classes/ImageView.swift
@@ -18,6 +18,7 @@ class ImageView: UIView, UIScrollViewDelegate {
     var scrollView: UIScrollView!
     var progressView: PhotoSlider.ProgressView!
     var delegate: PhotoSliderImageViewDelegate? = nil
+    weak var imageLoader: PhotoSlider.ImageLoader?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -144,26 +145,21 @@ class ImageView: UIView, UIScrollViewDelegate {
     }
     
     func loadImage(imageURL: URL) {
-        
         progressView.isHidden = false
-
-        imageView.kf.setImage(
-            with: imageURL,
-            placeholder: nil,
-            options: [.transition(.fade(1))],
-            progressBlock: { (receivedSize, totalSize) -> () in
-                
-                let progress = Float(receivedSize) / Float(totalSize)
-                self.progressView.animateCurveToProgress(progress: progress)
-
-            }) { (image, error, cacheType, imageURL) -> () in
-                self.progressView.isHidden = true
-                
-                if error == nil {
-                    self.layoutImageView(image: image!)
+        imageLoader?.load(
+            imageView: imageView,
+            fromURL: imageURL,
+            progress: { [weak self] (receivedSize, totalSize) in
+                let progress: Float = Float(receivedSize) / Float(totalSize)
+                self?.progressView.animateCurveToProgress(progress: progress)
+            },
+            completion: { [weak self] (image) in
+                self?.progressView.isHidden = true
+                if let image = image {
+                    self?.layoutImageView(image: image)
                 }
-        }
-        
+            }
+        )
     }
     
     func setImage(image:UIImage) {

--- a/Sources/Classes/KingfisherImageLoader.swift
+++ b/Sources/Classes/KingfisherImageLoader.swift
@@ -14,14 +14,16 @@ public class KingfisherImageLoader: ImageLoader {
         imageView: UIImageView?,
         fromURL url: URL?,
         progress: @escaping ImageLoader.ProgressBlock,
-        completion: @escaping ImageLoader.CompletionBlock)
-    {
+        completion: @escaping ImageLoader.CompletionBlock) {
         imageView?.kf.setImage(
             with: url,
             placeholder: nil,
             options: [.transition(.fade(1))],
             progressBlock: { (receivedSize, totalSize) in
-                progress(Int(truncatingBitPattern: receivedSize), Int(truncatingBitPattern: totalSize))
+                progress(
+                    Int(truncatingBitPattern: receivedSize),
+                    Int(truncatingBitPattern: totalSize)
+                )
             },
             completionHandler: { (image, error, _, _) in
                 if let image = image, error == nil {

--- a/Sources/Classes/KingfisherImageLoader.swift
+++ b/Sources/Classes/KingfisherImageLoader.swift
@@ -1,0 +1,35 @@
+//
+//  KingfisherImageLoader.swift
+//  PhotoSlider
+//
+//  Created by ChangHoon Jung on 2017. 1. 10..
+//  Copyright © 2017년 nakajijapan. All rights reserved.
+//
+
+import Foundation
+import Kingfisher
+
+public class KingfisherImageLoader: ImageLoader {
+    public func load(
+        imageView: UIImageView?,
+        fromURL url: URL?,
+        progress: @escaping ImageLoader.ProgressBlock,
+        completion: @escaping ImageLoader.CompletionBlock)
+    {
+        imageView?.kf.setImage(
+            with: url,
+            placeholder: nil,
+            options: [.transition(.fade(1))],
+            progressBlock: { (receivedSize, totalSize) in
+                progress(Int(truncatingBitPattern: receivedSize), Int(truncatingBitPattern: totalSize))
+            },
+            completionHandler: { (image, error, _, _) in
+                if let image = image, error == nil {
+                    completion(image)
+                } else {
+                    completion(nil)
+                }
+            }
+        )
+    }
+}

--- a/Sources/Classes/ViewController.swift
+++ b/Sources/Classes/ViewController.swift
@@ -49,9 +49,9 @@ public class ViewController:UIViewController {
     public var pageControl = UIPageControl()
     public var backgroundViewColor = UIColor.black
     public var captionTextColor = UIColor.white
-    
+
     public var imageLoader: PhotoSlider.ImageLoader?
-    
+
     public init(imageURLs:Array<URL>) {
         super.init(nibName: nil, bundle: nil)
         self.imageURLs = imageURLs
@@ -111,11 +111,11 @@ public class ViewController:UIViewController {
         let height = view.bounds.height
         var frame = view.bounds
         frame.origin.y = height
-        
+
         if imageLoader == nil {
             imageLoader = PhotoSlider.KingfisherImageLoader()
         }
-        
+
         for imageResource in imageResources()! {
             
             let imageView: PhotoSlider.ImageView = PhotoSlider.ImageView(frame: frame)

--- a/Sources/Classes/ViewController.swift
+++ b/Sources/Classes/ViewController.swift
@@ -49,6 +49,9 @@ public class ViewController:UIViewController {
     public var pageControl = UIPageControl()
     public var backgroundViewColor = UIColor.black
     public var captionTextColor = UIColor.white
+    
+    public var imageLoader: PhotoSlider.ImageLoader?
+    
     public init(imageURLs:Array<URL>) {
         super.init(nibName: nil, bundle: nil)
         self.imageURLs = imageURLs
@@ -108,10 +111,16 @@ public class ViewController:UIViewController {
         let height = view.bounds.height
         var frame = view.bounds
         frame.origin.y = height
+        
+        if imageLoader == nil {
+            imageLoader = PhotoSlider.KingfisherImageLoader()
+        }
+        
         for imageResource in imageResources()! {
             
             let imageView: PhotoSlider.ImageView = PhotoSlider.ImageView(frame: frame)
             imageView.delegate = self
+            imageView.imageLoader = imageLoader
             scrollView.addSubview(imageView)
             
             if imageResource is URL {


### PR DESCRIPTION
I use SDWebImage my project, but PhotoSlider use Kingfisher for remote image download.

In this case image cache is not shared between Kingfisher and SDWebImage.

So, this PR support multiple ImageLoader.
Default ImageLoader is Kingfisher for compatibility, but someday Kingfisher dependency is not necessary.