### PR TITLE
Add shadow to close button for white image

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "onevcat/Kingfisher" "3.1.3"
+github "onevcat/Kingfisher" "3.5.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "onevcat/Kingfisher" "3.5.2"
+github "onevcat/Kingfisher" "3.1.3"

--- a/Sources/Classes/ViewController.swift
+++ b/Sources/Classes/ViewController.swift
@@ -158,6 +158,10 @@ public class ViewController:UIViewController {
             closeButton!.addTarget(self, action: #selector(closeButtonDidTap(_:)), for: .touchUpInside)
             closeButton!.imageView?.contentMode = UIViewContentMode.center
             view.addSubview(closeButton!)
+            closeButton!.layer.shadowColor = UIColor.black.cgColor
+            closeButton!.layer.shadowOffset = CGSize(width: 1, height: 1)
+            closeButton!.layer.shadowRadius = 3
+            closeButton!.layer.shadowOpacity = 1
             layoutCloseButton()
         }
         


### PR DESCRIPTION
close button is not well see when image has white
so add black drop shadow to close button

sorry for PR Merge is not based latest master branch
my project needed iOS 8 support so i can't PR from latest master branch

![photoslider_pr](https://cloud.githubusercontent.com/assets/421486/24230395/40e9fc0a-0fc2-11e7-89f4-082dc31e5879.png)
