### PR TITLE
Fix crash on iOS11

### DIFF
--- a/Sources/Classes/ViewController.swift
+++ b/Sources/Classes/ViewController.swift
@@ -153,7 +153,7 @@ public class ViewController: UIViewController {
         view.backgroundColor = UIColor.clear
 
         view.addSubview(effectView)
-        effectView.addSubview(backgroundView)
+        effectView.contentView.addSubview(backgroundView)
 
         // scrollview setting for Item
         view.addSubview(scrollView)


### PR DESCRIPTION
I am using PhotoSlider with iOS 11 beta 6.
Tap a photo to crash the application.

```
2017-08-22 18:28:09.334135+0900 xxxxx[444:40044] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '<UIView: 0x10e60a670; frame = (0 0; 414 736); layer = <CALayer: 0x1c1828a60>> has been added as a subview to <UIVisualEffectView: 0x10e6f2de0; frame = (0 0; 414 736); layer = <CALayer: 0x1c1828700>>. Do not add subviews directly to the visual effect view itself, instead add them to the -contentView.'
```