### PR TITLE
[iOS11] Fix image hiding

### DIFF
--- a/Sources/Classes/ViewController.swift
+++ b/Sources/Classes/ViewController.swift
@@ -41,6 +41,10 @@ public class ViewController: UIViewController {
             height: self.view.bounds.height * 3.0
         )
 
+        if #available(iOS 11.0, *) {
+            scrollView.contentInsetAdjustmentBehavior = .never
+        }
+
         return scrollView
     }()
     


### PR DESCRIPTION
Fixed image hiding when `contentInsetAdjustmentBehavior` is the default value `.auto`.

## contentInsetAdjustmentBehavior = .auto (default)

![e427f535-04f7-4e3d-8879-1c0e4467ef0c](https://user-images.githubusercontent.com/236607/29663524-7ee29b9e-8906-11e7-834e-af7037644461.png)

## contentInsetAdjustmentBehavior = .never

![5dc03ba2-6016-46cd-808b-42db979ed668](https://user-images.githubusercontent.com/236607/29663526-82b6f936-8906-11e7-9b43-4f3b1ff57476.png)
